### PR TITLE
Skip tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ unit_test_promise.sublime-workspace
 test/tests.js
 test/tests.js.map
 .haxelib
+unit_test_promise.iml
+.idea

--- a/src/haxe/unit/async/PromiseTestRunner.hx
+++ b/src/haxe/unit/async/PromiseTestRunner.hx
@@ -19,9 +19,16 @@ typedef TestResult = {
 
 class PromiseTestRunner
 {
+	private var totalTestsRun :Int;
+	private var totalTestsPassed :Int;
+
 	public var onFinish :Void->Void;
 
-	public function new() :Void {}
+	public function new() :Void
+	{
+		totalTestsRun = 0;
+		totalTestsPassed = 0;
+	}
 
 	public function setDefaultTimeout(milliseconds :Int)
 	{
@@ -39,8 +46,8 @@ class PromiseTestRunner
 	{
 		var success = true;
 		var doTest = null;
-		var totalTestsRun = 0;
-		var totalTestsPassed = 0;
+		totalTestsRun = 0;
+		totalTestsPassed = 0;
 		doTest = function() {
 			if (_tests.length == 0) {
 				trace('TOTAL TESTS PASSED ${totalTestsPassed} / ${totalTestsRun}');
@@ -137,9 +144,34 @@ class PromiseTestRunner
 			}
 		}
 
-		nextTest(Type.getInstanceFields(Type.getClass(testObj)).filter(function(s) return s.startsWith("test")));
+		nextTest(getActiveTests(testObj));
 
 		return promise;
+	}
+
+	private static function getActiveTests(testObj :PromiseTest) :Array<String>
+	{
+		var testClass = Type.getClass(testObj);
+		return Type.getInstanceFields(testClass).filter(function (fieldName) {
+			if (fieldName.startsWith("test")) {
+				var fieldMetaData = Reflect.field(Meta.getFields(testClass), fieldName);
+				if (fieldMetaData == null || !Reflect.hasField(fieldMetaData, 'skip')) {
+					return true;
+				}
+			}
+
+			return false;
+		});
+	}
+
+	public function getTotalTestsRun() :Int
+	{
+		return totalTestsRun;
+	}
+
+	public function getTotalTestsPassed() :Int
+	{
+		return totalTestsPassed;
 	}
 
 	var _tests :Array<PromiseTest> = [];

--- a/test/Skip.hx
+++ b/test/Skip.hx
@@ -1,0 +1,15 @@
+import haxe.unit.async.PromiseTest;
+
+import promhx.Promise;
+
+class Skip extends PromiseTest
+{
+	public function new() {}
+
+	@skip
+	public function testNothing() :Promise<Bool>
+	{
+		trace("you shouldn't see this");
+		return Promise.promise(true);
+	}
+}

--- a/test/SkipTest.hx
+++ b/test/SkipTest.hx
@@ -1,0 +1,22 @@
+import haxe.unit.async.PromiseTest;
+import haxe.unit.async.PromiseTestRunner;
+
+import promhx.Promise;
+import promhx.Deferred;
+
+class SkipTest extends PromiseTest
+{
+	public function new() {}
+
+	public function testSkip() :Promise<Bool>
+	{
+		return Promise.promise(true)
+		.then(function (_) {
+			var runner = new PromiseTestRunner();
+			runner.add(new Skip());
+			runner.run();
+			assertEquals(runner.getTotalTestsRun(), 0);
+			return true;
+		});
+	}
+}

--- a/test/SkipTest.hx
+++ b/test/SkipTest.hx
@@ -2,7 +2,7 @@ import haxe.unit.async.PromiseTest;
 import haxe.unit.async.PromiseTestRunner;
 
 import promhx.Promise;
-import promhx.Deferred;
+import promhx.deferred.DeferredPromise;
 
 class SkipTest extends PromiseTest
 {
@@ -11,12 +11,19 @@ class SkipTest extends PromiseTest
 	public function testSkip() :Promise<Bool>
 	{
 		return Promise.promise(true)
-		.then(function (_) {
-			var runner = new PromiseTestRunner();
-			runner.add(new Skip());
-			runner.run();
-			assertEquals(runner.getTotalTestsRun(), 0);
-			return true;
+			.pipe(function (_) {
+				var runner = new PromiseTestRunner();
+				runner.add(new Skip());
+				runner.setSkipExit(true);
+				var deferred = new DeferredPromise();
+				runner.run().onFinish = function() {
+					if (runner.getTotalTestsRun() == 0) {
+						deferred.resolve(true);
+					} else {
+						deferred.boundPromise.reject('runner.getTotalTestsRun()=${runner.getTotalTestsRun()}');
+					}
+				};
+				return deferred.boundPromise;
 		});
 	}
 }

--- a/test/Tests.hx
+++ b/test/Tests.hx
@@ -7,7 +7,7 @@ class Tests
 		new PromiseTestRunner()
 			.add(new Test1())
 			.add(new Test2())
-			.add(new Skip())
+			.add(new SkipTest())
 			.run().onFinish = function() trace("Finished!");
 	}
 }

--- a/test/Tests.hx
+++ b/test/Tests.hx
@@ -7,6 +7,7 @@ class Tests
 		new PromiseTestRunner()
 			.add(new Test1())
 			.add(new Test2())
+			.add(new Skip())
 			.run().onFinish = function() trace("Finished!");
 	}
 }

--- a/test/travis.hxml
+++ b/test/travis.hxml
@@ -3,6 +3,7 @@
 -D nodejs
 
 -lib promhx
+-lib nodejs
 
 -cp lib/haxe-js-kit
 -cp src


### PR DESCRIPTION
This PR adds the ability to skip tests using the `@skip` attribute. It also includes some additional functionality to the PromiseTestRunner class that was required to properly test that a test IS skipped. I fixed a bug where an unsuccessful exit was only reported when tests run were less than tests passed instead of tests passed being less than tests run.
